### PR TITLE
Potential fix for code scanning alert no. 42: Query built from user-controlled sources

### DIFF
--- a/src/main/java/org/owasp/webgoat/lessons/sqlinjection/mitigation/Servers.java
+++ b/src/main/java/org/owasp/webgoat/lessons/sqlinjection/mitigation/Servers.java
@@ -48,13 +48,16 @@ public class Servers {
   @ResponseBody
   public List<Server> sort(@RequestParam String column) throws Exception {
     List<Server> servers = new ArrayList<>();
+    List<String> allowedColumns = List.of("id", "hostname", "ip", "mac", "status", "description");
+
+    if (!allowedColumns.contains(column)) {
+      throw new IllegalArgumentException("Invalid column name");
+    }
+
+    String query = "select id, hostname, ip, mac, status, description from SERVERS where status <> 'out of order' order by " + column;
 
     try (var connection = dataSource.getConnection()) {
-      try (var statement =
-          connection.prepareStatement(
-              "select id, hostname, ip, mac, status, description from SERVERS where status <> 'out"
-                  + " of order' order by "
-                  + column)) {
+      try (var statement = connection.prepareStatement(query)) {
         try (var rs = statement.executeQuery()) {
           while (rs.next()) {
             Server server =


### PR DESCRIPTION
Potential fix for [https://github.com/vaitorzp/UCM_WebGoat/security/code-scanning/42](https://github.com/vaitorzp/UCM_WebGoat/security/code-scanning/42)

To fix the problem, we need to avoid using string concatenation to build the SQL query. Instead, we should use a parameterized query with placeholders for the user-provided values. Since the `column` parameter is used for sorting, we need to validate it against a list of allowed column names to prevent SQL injection.

1. Create a list of allowed column names.
2. Validate the `column` parameter against this list.
3. Use a parameterized query to safely include the validated column name in the SQL query.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
